### PR TITLE
Fix pickle problems. Remove Galileo v1 metadata indexes.

### DIFF
--- a/pdsfile.py
+++ b/pdsfile.py
@@ -1075,7 +1075,9 @@ class PdsFile(object):
                     return True
 
                 # Maybe there's an associated shelf file in the infoshelf tree
-                if os.path.exists(shelf_abspath + '_info.shelf'):
+                if (os.path.exists(shelf_abspath + '_info.shelf') or
+                    (USE_PICKLES and
+                     os.path.exists(shelf_abspath + '_info.pickle'))):
                     return True
 
                 # Checksum files need special handling
@@ -1117,7 +1119,9 @@ class PdsFile(object):
                     return True
 
                 # Maybe there's an associated shelf file in the infoshelf tree
-                if os.path.exists(shelf_abspath + '_info.shelf'):
+                if (os.path.exists(shelf_abspath + '_info.shelf') or
+                    (USE_PICKLES and
+                     os.path.exists(shelf_abspath + '_info.pickle'))):
                     return True
 
                 # Checksum files need special handling
@@ -1266,6 +1270,8 @@ class PdsFile(object):
 
         # Handle wildcards in the shelf path, if any
         if '*' in shelf_path or '?' in shelf_path or '[' in shelf_path:
+            if USE_PICKLES:
+                shelf_path = shelf_path.replace('.shelf', '.pickle')
             shelf_paths = _clean_glob(shelf_path)
         else:
             shelf_paths = [shelf_path]

--- a/rules/GO_0xxx.py
+++ b/rules/GO_0xxx.py
@@ -145,9 +145,7 @@ opus_products = translator.TranslatorByRegex([
                                                                            r'previews/\1_v1/\2/\3/\4_med.jpg',
                                                                            r'previews/\1_v1/\2/\3/\4_full.jpg',
                                                                            r'metadata/\1/\2/\2_index.lbl',
-                                                                           r'metadata/\1/\2/\2_index.tab',
-                                                                           r'metadata/\1_v1/\2/\2_index.lbl',
-                                                                           r'metadata/\1_v1/\2/\2_index.tab']),
+                                                                           r'metadata/\1/\2/\2_index.tab']),
 ])
 
 ####################################################################################################################################


### PR DESCRIPTION
Dave - These changes pass in "pickles_only" mode, but please test them using the full test suite on your Mac.
